### PR TITLE
fix vww build on OS X (and maybe other platforms)

### DIFF
--- a/v0.1/example_submission/download_and_build_tfmicro.sh
+++ b/v0.1/example_submission/download_and_build_tfmicro.sh
@@ -6,6 +6,6 @@ if [ ! -f "$TFMICRO_BINARY" ]; then
   mv -f tensorflow-master/tensorflow .
   rm -rf tensorflow-master
   make -f tensorflow/lite/micro/tools/make/Makefile microlite -j18
-  mv tensorflow/lite/micro/tools/make/gen/linux_x86_64/lib/libtensorflow-microlite.a .
+  mv tensorflow/lite/micro/tools/make/gen/*/lib/libtensorflow-microlite.a .
   rm master.zip
 fi


### PR DESCRIPTION
The code is a quick workaround to remove the assumption that
the build was done on linux_x86_64.

Signed-off-by: Csaba Kiraly <csaba.kiraly@gmail.com>